### PR TITLE
Ability to restore all mocks created

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ Mocker.prototype.timesCalled = function() {
   return this.history.length;
 };
 
+var mocks = [];
 
 /**
  * Creates a new Mocker
@@ -65,5 +66,21 @@ Mocker.prototype.timesCalled = function() {
  * @api public
  */
 exports.mock = function(obj, methodName, mockFn) {
-  return new Mocker(obj, methodName, mockFn);
+  var mock = new Mocker(obj, methodName, mockFn);
+  
+  mocks.push(mock);
+  
+  return mock;
 };
+
+/**
+ * Restores all mocks and release
+ *
+ * @api public
+ */
+exports.restore = function(){
+  for (var i = 0; i < mocks.length; i++) {
+    mocks[i].restore();
+  }
+  mocks = [];
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -170,5 +170,30 @@ exports['mocker'] = {
     test.same(mock.timesCalled(), 3);
 
     test.done();
-  }
+  },
+
+  'restore() restores all mocks created since last restore': function(test) {
+    mocker.restore();
+    
+    var originalFind = User.find,
+        originalFullName = User.prototype.fullName,
+        mockedString = 'mocked!',
+        mockFind = function() { return mockedString; }
+        mockFullName = mockFind;    
+    
+    var newMocks = [
+      mocker.mock(User, 'find', mockFind),
+      mocker.mock(User.prototype, 'fullName', mockFullName)
+    ];
+    
+    test.same(User.find(), mockedString);
+    test.same((new User('a', 'b')).fullName(), mockedString);
+    
+    mocker.restore();
+    
+    test.same(User.find, originalFind);
+    test.same(User.prototype.fullName, originalFullName);
+    
+    test.done();
+  } 
 };


### PR DESCRIPTION
Calling exports.restore() calls mock.restore() on all mocks created, or since last call of exports.restore().
